### PR TITLE
Add toggleable DOMPick helper Chrome extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,122 @@
+/*
+ * DOMPick Helper Toggle Service Worker (Manifest V3)
+ * -------------------------------------------------
+ * Event flow overview:
+ * 1. User clicks the action icon.
+ *    - Toggle ON/OFF state for current tab.
+ *    - ON: inject helper.js into page (world: MAIN).
+ *    - OFF: send DOMPICK_DISABLE message to content script to close panel.
+ * 2. When a tab with ON state finishes loading (tabs.onUpdated status "complete"),
+ *    the helper is reinjected automatically.
+ * 3. Tab state is stored both in-memory and in chrome.storage.session so that
+ *    it survives service worker restarts.
+ * 4. Tab replacement (tabs.onReplaced) transfers or clears state to avoid
+ *    leaking ON flags for old tabIds.
+ * 5. Closing a tab cleans up its state.
+ */
+
+const tabStates = new Map(); // tabId -> boolean
+
+initState();
+
+// Restore state from chrome.storage.session when the service worker starts.
+async function initState() {
+  const stored = await chrome.storage.session.get(null);
+  for (const [key, value] of Object.entries(stored)) {
+    const id = Number(key);
+    tabStates.set(id, value);
+    updateAction(id); // restore icon/badge
+  }
+}
+
+// Utility to check if a tab's URL is restricted
+function isForbidden(tab) {
+  const url = tab.url || "";
+  return (
+    url.startsWith("chrome://") ||
+    url.startsWith("chrome-extension://") ||
+    url.startsWith("https://chrome.google.com/webstore")
+  );
+}
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.id) return;
+  if (isForbidden(tab)) {
+    updateAction(tab.id, true);
+    return;
+  }
+  const current = tabStates.get(tab.id) === true;
+  const next = !current;
+  await setTabState(tab.id, next);
+  if (next) {
+    injectHelper(tab.id);
+  } else {
+    chrome.tabs.sendMessage(tab.id, { type: "DOMPICK_DISABLE" }).catch(() => {});
+  }
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete" && tabStates.get(tabId)) {
+    injectHelper(tabId);
+  }
+});
+
+// When a tab is replaced (e.g., prerendered or restored), move any ON state
+// from the old tabId to the new one and inject if necessary.
+chrome.tabs.onReplaced.addListener(async (addedId, removedId) => {
+  const wasOn = tabStates.get(removedId);
+  tabStates.delete(removedId);
+  chrome.storage.session.remove(removedId.toString());
+  if (wasOn) {
+    tabStates.set(addedId, true);
+    await chrome.storage.session.set({ [addedId]: true });
+    injectHelper(addedId);
+  } else {
+    updateAction(addedId);
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  tabStates.delete(tabId);
+  chrome.storage.session.remove(tabId.toString());
+});
+
+async function setTabState(tabId, isOn) {
+  tabStates.set(tabId, isOn);
+  await chrome.storage.session.set({ [tabId]: isOn });
+  updateAction(tabId);
+}
+
+function updateAction(tabId, err = false) {
+  const isOn = tabStates.get(tabId);
+  const base = isOn ? "icons/icon_on" : "icons/icon";
+  chrome.action.setIcon({
+    tabId,
+    path: {
+      16: `${base}16.png`,
+      32: `${base}32.png`,
+      48: `${base}48.png`,
+      128: `${base}128.png`,
+    },
+  });
+  chrome.action.setBadgeText({ tabId, text: err ? "ERR" : isOn ? "ON" : "" });
+}
+
+async function injectHelper(tabId) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (isForbidden(tab)) {
+      updateAction(tabId, true);
+      return;
+    }
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      files: ["helper.js"],
+    });
+    updateAction(tabId);
+  } catch (e) {
+    console.warn("Injection failed", e);
+    updateAction(tabId, true);
+  }
+}

--- a/content/toggle-listener.js
+++ b/content/toggle-listener.js
@@ -1,0 +1,10 @@
+// Listens for disable messages and closes DOMPick panel if present.
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg && msg.type === "DOMPICK_DISABLE") {
+    try {
+      document.getElementById("__dompick-close")?.click();
+    } catch (e) {
+      // Ignore errors, panel just won't be closed.
+    }
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "DOMPick Helper Toggle",
+  "version": "1.0.0",
+  "description": "Toggle injection of helper.js for DOMPick.",
+  "permissions": ["action", "scripting", "tabs", "activeTab", "storage"],
+  "host_permissions": ["<all_urls>"],
+  "background": { "service_worker": "background.js" },
+  "action": {
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "32": "icons/icon32.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    },
+    "default_title": "DOMPick Helper"
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/toggle-listener.js"],
+      "run_at": "document_start"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Manifest V3 extension that injects helper.js into pages
- toggle per-tab ON/OFF state via action icon and reinject on reload
- include content listener for disabling helper and placeholder icons paths
- handle tab replacements to transfer or clear stored state
- remove committed placeholder PNG icon assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a340abbc83238746938c4173f9dc